### PR TITLE
Enable Player Nickname Updates

### DIFF
--- a/src/api/leaderboard.js
+++ b/src/api/leaderboard.js
@@ -6,12 +6,44 @@ import { supabase } from "./supabaseClient.js";
  * @param {string} nickname - Chosen by the user.
  */
 export async function registerPlayer(playerId, nickname) {
+
+    // 1) check if there is an existing name on this session (playerId)
+    const { data: existing, error: selectError } = await supabase
+        .from("players")
+        .select("nickname")
+        .eq("id", playerId)
+        .single();
+
+    // error catching
+    if (selectError && selectError.code !== "PGRST116") {
+        console.error("Failed to check existing player:", selectError);
+        return { data: null, error: selectError };
+    }
+
+    // 2) if there is no player info, register this player
+    if (!existing) {
+        const { data, error } = await supabase
+            .from("players")
+            .insert([{ id: playerId, nickname }])
+            .select();
+
+        if (error) console.error("Failed to register player:", error);
+        return { data, error };
+    }
+
+    // 3) if there is already the same name for this player, pass
+    if (existing.nickname === nickname) {
+        return { data: existing, error: null };
+    }
+
+    // 4) if there is already a name for this player, but it is different, update the name as the latest name.
     const { data, error } = await supabase
         .from("players")
-        .insert([{ id: playerId, nickname }])
+        .update({ nickname })
+        .eq("id", playerId)
         .select();
 
-    if (error) console.error("Failed to register player:", error);
+    if (error) console.error("Failed to update nickname:", error);
     return { data, error };
 }
 
@@ -20,14 +52,53 @@ export async function registerPlayer(playerId, nickname) {
  * @param {Object} sessionData - Gameplay result payload.
  */
 export async function submitGameSession(sessionData) {
+    const playerId = sessionData.player_id;
+    const newScore = sessionData.score;
+
+    // 1) Check if existing session exists
+    const { data: existing, error: selectError } = await supabase
+        .from("game_sessions")
+        .select("*")
+        .eq("player_id", playerId)
+        .single();
+
+    if (selectError && selectError.code !== "PGRST116") {
+        console.error("Failed to check existing session:", selectError);
+        return { data: null, error: selectError };
+    }
+
+    // 2) First session → INSERT
+    if (!existing) {
+        const { data, error } = await supabase
+            .from("game_sessions")
+            .insert([sessionData])
+            .select();
+
+        if (error) console.error("Failed to insert game session:", error);
+        return { data, error };
+    }
+
+    // 3) Existing → UPDATE (highest score)
+    const updatePayload = {
+        play_time: sessionData.play_time,
+        hits: sessionData.hits,
+        pickups: sessionData.pickups,
+        max_speed: sessionData.max_speed,
+        max_jump_power: sessionData.max_jump_power,
+        health_left: sessionData.health_left,
+        score: Math.max(existing.score, newScore)
+    };
+
     const { data, error } = await supabase
         .from("game_sessions")
-        .insert([sessionData])
+        .update(updatePayload)
+        .eq("player_id", playerId)
         .select();
 
-    if (error) console.error("Failed to submit session:", error);
+    if (error) console.error("Failed to update game session:", error);
     return { data, error };
 }
+
 
 /**
  * Fetch top scores from the leaderboard.

--- a/src/scenes/MenuScene.js
+++ b/src/scenes/MenuScene.js
@@ -83,23 +83,39 @@ export default class MenuScene extends Phaser.Scene {
             fontSize: "24px",
             fill: "#ffffff"
         });
+        await this.refreshLeaderboard();
+
+        this.events.on("wake", async () => {
+            await this.refreshLeaderboard();
+        });
+    }
+
+    async refreshLeaderboard() {
+        if (this.leaderboardTexts) {
+            this.leaderboardTexts.forEach(t => t.destroy());
+        }
+        this.leaderboardTexts = [];
 
         const { data, error } = await fetchLeaderboard(10);
 
         if (error) {
             console.error("Failed to load leaderboard:", error);
-        } else {
-            data.forEach((row, i) => {
-                const nickname = row.players?.nickname || "Unknown";
-                const score = row.score;
-
-                this.add.text(
-                    350,
-                    160 + i * 24,
-                    `${i + 1}. ${nickname} — ${score}`,
-                    { fontSize: "20px", fill: "#ffffff" }
-                );
-            });
+            return;
         }
+
+        data.forEach((row, i) => {
+            const nickname = row.players?.nickname || "Unknown";
+            const score = row.score;
+
+            const text = this.add.text(
+                350,
+                160 + i * 24,
+                `${i + 1}. ${nickname} — ${score}`,
+                { fontSize: "20px", fill: "#ffffff" }
+            );
+
+            this.leaderboardTexts.push(text);
+        });
     }
+
 }


### PR DESCRIPTION
## Summary

This PR updates the player registration and session handling logic to properly support nickname changes.

Closes #12 

Previously, a player’s nickname was fixed on first registration and could not be updated.
This update allows players to freely change their nickname while still preserving their identity through the stored UUID (which will be stored in user's local storage).

## Purpose

* Allow players to update their nickname even after the first registration.

* Keep one-player–one-UUID identity consistent across sessions.

* Ensure game sessions always track the correct player and display updated nicknames in the leaderboard.

---

## Major Changes

Check all that apply:

* [ ] Game Logic (Phaser scenes, collision, spawning, etc.)
* [ ] UI / Graphics / Animation
* [x] Scoring / Leaderboard System
* [ ] Dependency changes
* [ ] Documentation updates
* [x] Refactoring / Project structure changes

---

## How to Test

1. Launch the game and enter a nickname.

2. Start a game → finish a run → return to main menu.

3. Change the nickname and start again.

### Confirm:

* nickname is updated in the players table

* previous score/session data remains associated with the same UUID

* leaderboard displays the latest nickname

* Close the browser, reopen the game, and confirm the same player is recognized via localStorage UUID.

---

## Screenshots / Logs (Optional)

Attach screenshots, GIFs, or logs if helpful.

---

## Checklist

* [x] Local tests passed
* [x] Verified on at least one major browser (**Chrome**/Firefox/Safari)
* [x] Linked the relevant issue (e.g., `Closes #123`)
* [x] Followed the project’s Code of Conduct and Contribution Guidelines

---

## Additional Notes (Optional)

* Add context or notes for reviewers
* Mention anything that may need discussion (difficulty balance, scoring adjustments, new assets, etc.)

* NSTR