### PR TITLE
Fix DOM Input Focus & Enable Enter to Start Game

### DIFF
--- a/src/scenes/MenuScene.js
+++ b/src/scenes/MenuScene.js
@@ -89,7 +89,7 @@ export default class MenuScene extends Phaser.Scene {
             "keydown",
             (e) => {
                 if (document.activeElement === nicknameInput) {
-                    // WASD만 Phaser에게 전달되지 않게 막기
+                    // Prevent only the WASD keys from being passed to Phaser (if more key are used to operate game, we should put keys into it)
                     if (["w", "a", "s", "d", "W", "A", "S", "D"].includes(e.key)) {
                         e.stopImmediatePropagation();
                     }


### PR DESCRIPTION
## **Summary**

Closes #14 

This pull request fixes a long-standing issue where returning from `GameScene` to `MenuScene` caused **WASD input to stop working inside the DOM nickname input**, preventing English characters from being typed.
Additionally, pressing **Enter** inside the nickname input correctly starts the game again.

This contributes to the project goals by ensuring a smooth gameplay loop, stable UI input handling, and intuitive game start behavior.

---

## **Purpose**

This change is necessary because:

* When exiting `GameScene` with ESC and returning to `MenuScene`, the Phaser canvas forcibly took focus.
* As a result, WASD inputs were captured by Phaser and never reached the DOM input field.
* The fix ensures the nickname input behaves normally even after scene transitions.
* Enter key now consistently starts the game, improving UX and flow.
---

## **Major Changes**

* [x] Game Logic (scene transition input behavior)
* [x] UI / Graphics / Animation (nickname input focus & usability)
* [ ] Scoring / Leaderboard System
* [ ] Dependency changes
* [ ] Documentation updates
* [x] Refactoring / Project structure changes (input event handling improvements)

---

## **How to Test**

1. Run the game locally with `npm run dev`.
2. On the MenuScene:

   * Type WASD → all letters should appear normally in the input field.
   * Press **Enter** → game should start immediately.
   * Click **Start Game** → also starts the game.
3. In the GameScene:

   * Press **ESC** to return to MenuScene.
   * Type WASD again → still works normally.
   * Enter key → again starts the game.

### **Expected Result**

* WASD inputs are not blocked in the nickname input field.
* Phaser canvas no longer steals focus.
* Enter reliably triggers `startGame()`.
* GameScene keyboard controls remain unaffected.

---

## **Screenshots / Logs (Optional)**

---

## **Checklist**

* [x] Local tests passed
* [x] Verified on at least one major browser (Chrome) 
* [x] Linked the relevant issue (e.g., Closes #123) 
* [x] Followed the project’s Code of Conduct and Contribution Guidelines

---

## **Additional Notes (Optional)**

* Reviewers should check if additional UI elements will require similar focus handling.