### PR TITLE
Fixing issue #6

### DIFF
--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -68,17 +68,14 @@ export default class GameScene extends Phaser.Scene {
     this.updateStatsText();
   }
 
-  update() {
-    this.player.update();
-    this.world.update();
-    //fix later (issue created)
-    this.updateStatsText();
-    if (Phaser.Input.Keyboard.JustDown(this.escapeKey)) {
-        this.endGame();
-    }
+update() {
+  this.player.update();
+  this.world.update();
 
-
+  if (Phaser.Input.Keyboard.JustDown(this.escapeKey)) {
+    this.endGame();
   }
+}
 
   handlePickup(player, pickup) {
     if (pickup instanceof HealthPickup) {
@@ -90,6 +87,8 @@ export default class GameScene extends Phaser.Scene {
     }
     this.pickupCount++;
     pickup.destroy();
+
+    this.updateStatsText();
   }
 
   handleEnemyCollision(player, enemy) {


### PR DESCRIPTION
This fixes the problem with issue #6:
GameScene calls updateStatsText() every delta

I have removed this.updateStatsText(); from the update() loop in GameScene so the stats UI is no longer updated every frame. Instead, updateStatsText() is now called from handlePickup(), so it only runs when the player’s stats actually change due to a new pickup.

Closes #6

## Summary

This pull request optimizes how the stats UI is updated in the GameScene:
* Removes the per-frame call to updateStatsText() from update().
* Keeps the initial stats text setup in create().
* Calls updateStatsText() from handlePickup() so the UI only updates when pickups change the player’s stats (health, speed, jump, etc.).

This keeps the runner gameplay exactly the same while making the scene logic and UI updates more efficient and easier to extend later (e.g. when adding more stats, scoring, or leaderboard-related info).

## Purpose

* Avoid unnecessary UI updates every frame and reduce redundant calls to setText().
* Clean up the scene logic so stats updates happen only when underlying data changes (on pickups), which is a more maintainable pattern.
* Prepare the codebase for future extensions (e.g. more detailed stats, scoring, or visual effects) without doing extra work each frame.

In short: this is a small performance/cleanliness improvement that doesn’t change gameplay but makes the GameScene more efficient and easier to reason about.

---

## Major Changes

Check all that apply:

* [x] Game Logic (Phaser scenes, collision, spawning, etc.)
* [ ] UI / Graphics / Animation
* [ ] Scoring / Leaderboard System
* [ ] Dependency changes
* [ ] Documentation updates
* [x] Refactoring / Project structure changes

---

## How to Test

1.	Run the game locally
2.	Open the dev server in a browser (e.g. Chrome):
* Usually: http://localhost:5173
3.	Verify stats behavior
* Start a run and look at the stats text in the top-left.
* The stats should:
* Initialize correctly when the scene starts.
* Only change when you collect pickups that affect:
* Health
* Move speed
* Jump power
* Max jumps
* Stats should not visibly flicker or behave differently compared to before, except that they are no longer updated every frame.
4.	Verify existing gameplay still works
* Player movement, jumping, collisions, and pickups still behave as expected.
* Pressing ESC still ends the run and triggers endGame() as before.
* No new errors appear in the browser console.

---

## Screenshots / Logs (Optional)

Attach screenshots, GIFs, or logs if helpful.

---

## Checklist

* [x] Local tests passed
* [x] Verified on at least one major browser (Chrome/Firefox/Safari)
* [x] Linked the relevant issue (e.g., `Closes #123`)
* [x] Followed the project’s Code of Conduct and Contribution Guidelines

---

## Additional Notes (Optional)

* If future features change player stats outside of handlePickup() (e.g. damage over time, enemy hits affecting health, or buffs from other systems), those places should also call updateStatsText() to keep the UI in sync.

