### PR TITLE
feat (leaderboard): add personal score and rank

### DIFF
--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -19,6 +19,11 @@ export default class GameScene extends Phaser.Scene {
   create() {
     this.world = new ScrollingWorld(this, 32, 150);
     this.player = new Player(this, 100, 250);
+
+    this.add.image(0, 0, 'bg')
+      .setOrigin(0, 0)
+      .setScrollFactor(0)
+      .setDepth(-10);
     // for temperary escape key to terminate game and see statistics
     this.escapeKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ESC);
     // for count how many pickups occured
@@ -68,17 +73,14 @@ export default class GameScene extends Phaser.Scene {
     this.updateStatsText();
   }
 
-  update() {
-    this.player.update();
-    this.world.update();
-    //fix later (issue created)
-    this.updateStatsText();
-    if (Phaser.Input.Keyboard.JustDown(this.escapeKey)) {
-        this.endGame();
-    }
+update() {
+  this.player.update();
+  this.world.update();
 
-
+  if (Phaser.Input.Keyboard.JustDown(this.escapeKey)) {
+    this.endGame();
   }
+}
 
   handlePickup(player, pickup) {
     if (pickup instanceof HealthPickup) {
@@ -90,6 +92,8 @@ export default class GameScene extends Phaser.Scene {
     }
     this.pickupCount++;
     pickup.destroy();
+
+    this.updateStatsText();
   }
 
   handleEnemyCollision(player, enemy) {

--- a/src/scenes/MenuScene.js
+++ b/src/scenes/MenuScene.js
@@ -166,6 +166,37 @@ export default class MenuScene extends Phaser.Scene {
             }
         }
 
+        // ================================================
+        // PERSONAL INFO
+        // ================================================
+        let myRank = null;
+        let myBestScore = null;
+
+        for (let i = 0; i < unique.length; i++) {
+            const row = unique[i];
+            if (row.player_id === playerId) {
+                myRank = i + 1;
+                myBestScore = row.score;
+                break;
+            }
+        }
+        if (this.personalInfoTexts) {
+            this.personalInfoTexts.forEach(t => t.destroy());
+        }
+        this.personalInfoTexts = [];
+
+        const baseY = 170;
+
+        const bestScoreText = this.add.text(
+            350,
+            baseY - 80,
+            `Your Best: ${myBestScore ?? "-"} points & Your Rank: ${myRank ? "#" + myRank : "-"}/${unique.length}`,
+            { fontSize: "20px", fill: "#ffffff" }
+        );
+
+        this.personalInfoTexts.push(bestScoreText);
+
+
         const top = unique.slice(0, limit);
 
         const medals = ["🥇", "🥈", "🥉"];


### PR DESCRIPTION
## Summary

* This is the initial version of our leaderboard and closes #2 

## Purpose

* We can see top 10 players with their scores and our personal rank with scores
* **enhance leaderboard**

---

## Major Changes

Check all that apply:

* [ ] Game Logic (Phaser scenes, collision, spawning, etc.)
* [x] UI / Graphics / Animation
* [X] Scoring / Leaderboard System
* [ ] Dependency changes
* [ ] Documentation updates
* [ ] Refactoring / Project structure changes

---

## How to Test

1. run `npm install` and `npm run dev` in your CLI
2. See the scores are matching from top 10 and your personal score
3. After playing a game, check if the highest score has changed.

---

## Screenshots / Logs (Optional)

<img width="2394" height="900" alt="image" src="https://github.com/user-attachments/assets/bded187c-eb63-4dda-8827-f64f5a0c3122" />


---

## Checklist

* [x] Local tests passed
* [x] Verified on at least one major browser (Chrome/Firefox/Safari)
* [x] Linked the relevant issue (e.g., `Closes #123`)
* [x] Followed the project’s Code of Conduct and Contribution Guidelines

---

## Additional Notes (Optional)

* NSTR

